### PR TITLE
Fix header formatting in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-##Gram Like Cam
+## Gram Like Cam
 
 From half of the same team that brought you [goatattack](https://goatattack.com) is their next stupid adventure, but this one is open source. #keeppounding
 


### PR DESCRIPTION
Github-flavoured markdown requires a space after the hash symbols to properly
generate the rich text. This commit adds that space.